### PR TITLE
Disabling dropdown for search.

### DIFF
--- a/app/views/simulator.html
+++ b/app/views/simulator.html
@@ -31,11 +31,11 @@
             </div>
           </div>
           <div class="my-dropdown-menu">
-            <input class="input-medium search my-dropdown-focus" type="text" name="name"
+            <input class="input-medium search my-dropdown-focus" type="search" name="name"
                    ng-model="recipeSearch.text"
                    placeholder="{{ 'RECIPE_SEARCH' | translate }}" select-on-focus stop-click-propogation
                    ng-keypress="onSearchKeyPress($event)" ng-keydown="onSearchKeyDown($event)"
-                   id="recipe-search-text"/>
+                   id="recipe-search-text" autocomplete="off"/>
             <ul class="recipe-menu-scrollable" isolate-scrolling>
               <li class="loading" ng-show="recipeSearch.loading"><i class="fa fa-spinner fa-spin"></i> {{'LOADING' | translate}}
               </li>

--- a/app/views/solver.html
+++ b/app/views/solver.html
@@ -40,11 +40,11 @@
             </div>
           </div>
           <div class="my-dropdown-menu">
-            <input class="input-medium search my-dropdown-focus" type="text" name="name"
+            <input class="input-medium search my-dropdown-focus" type="search" name="name"
                    ng-model="recipeSearch.text"
                    placeholder="{{ 'RECIPE_SEARCH' | translate }}" select-on-focus stop-click-propogation
                    ng-keypress="onSearchKeyPress($event)" ng-keydown="onSearchKeyDown($event)"
-                   id="recipe-search-text"/>
+                   id="recipe-search-text" autocomplete="off"/>
             <ul class="recipe-menu-scrollable" isolate-scrolling>
               <li class="loading" ng-show="recipeSearch.loading"><i class="fa fa-spinner fa-spin"></i> {{'LOADING' | translate}}
               </li>


### PR DESCRIPTION
Totally fine if this isn't a UX thing you want, but since I was using your fork and changed this locally, I wanted to give back some. I found it annoying to have the search field for the recipes trying to autocomplete past searches while it was also filtering the list of options, since the dropdown for the autocomplete would overlap the filtered list, so I disabled it.

If you want, I've also been working on tweaking the solver here and there, and could contribute back some changes that I think work, but I don't have anything major yet.