### PR TITLE
Allow unquoted ability names when importing macros

### DIFF
--- a/app/js/controllers/macroimport.js
+++ b/app/js/controllers/macroimport.js
@@ -39,11 +39,11 @@
         return undefined;
       }
 
-      var regex = /\/ac(tion)?\s+"(.*?)"\s*<wait\.\d+>/g;
+      var regex = /\/ac(tion)?\s+(")?(.*?)\2\s*<wait\.\d+>/g;
       var newSequence = [];
       var result;
       while (result = regex.exec(macroString)) {
-        var action = result[2];
+        var action = result[3];
         for (var key in _actionsByName) {
           var value = _actionsByName[key];
           if (action === value.name || action === $translate.instant(value.name)) {


### PR DESCRIPTION
Currently, ability names have to be quoted when importing macros. However, websites like [TeamCraft](https://ffxivteamcraft.com/) only include quotes when they're required, which is how it also works in-game.

This patch changes the ability-detecting regex so that it can detect abilities with and without quotes.

For example, this now imports correctly:

```text
/ac Reflect <wait.3>
/ac "Master's Mend" <wait.3>
/ac "Waste Not II" <wait.2>
/ac Innovation <wait.2>
/ac "Preparatory Touch" <wait.3>
/ac "Preparatory Touch" <wait.3>
/ac "Delicate Synthesis" <wait.3>
/ac "Byregot's Blessing" <wait.3>
/ac Groundwork <wait.3>
```