### PR TITLE
Fix macro import with missing quotes

### DIFF
--- a/app/js/controllers/macroimport.js
+++ b/app/js/controllers/macroimport.js
@@ -39,7 +39,7 @@
         return undefined;
       }
 
-      var regex = /\/ac(tion)?\s+"(.*?)"\s*<wait\.\d+>/g;
+      var regex = /\/ac(tion)?\s+"?(.*?)"?\s*<wait\.\d+>/g;
       var newSequence = [];
       var result;
       while (result = regex.exec(macroString)) {


### PR DESCRIPTION
Some macros would fail to be imported, typically from Teamcraft where the line would look like
`/ac Foobar <wait.2>` instead of `/ac "Foobar" <wait.2>`
