### PR TITLE
Add option to generate a single macro with all the steps

### DIFF
--- a/app/js/components/macros.js
+++ b/app/js/components/macros.js
@@ -138,7 +138,7 @@
         macroTime += line.time;
         macroLineCount += 1;
 
-        if (macroLineCount === MAX_LINES - 1) {
+        if (!options.singleMacro && macroLineCount === MAX_LINES - 1) {
           if (lines.length - (j + 1) > 1) {
 
             if(options.useNextMacro) {
@@ -164,7 +164,7 @@
       }
 
       if (macroLineCount > 0) {
-        if (macroLineCount < MAX_LINES) {
+        if (options.singleMacro || macroLineCount < MAX_LINES) {
           macroString += '/echo Macro #' + macroIndex + ' complete ' + soundEffect(options.finishSoundEffect, options.stepSoundEnabled) + '\n';
         }
         macroList.push({text: macroString, time: macroTime});

--- a/app/modals/options.html
+++ b/app/modals/options.html
@@ -289,6 +289,13 @@
                                                         {{ 'MACRO_NEXTMACRO' | translate }}
                                                     </label>
                                                 </div>
+
+                                                <div class="controls">
+                                                    <label class="checkbox">
+                                                      <input type="checkbox" name="singleMacroOption" ng-model="macroOptions.singleMacro"/>
+                                                      Single Macro
+                                                    </label>
+                                                </div>
                                             </div>
                                         </div>
                                     </div>


### PR DESCRIPTION
This makes it easier for some sites to import the macro if it's in a single block instead of segmented into 15 actions blocks.
This will need localization support later as I do not know how to add it.